### PR TITLE
Show Effect Knob Values onclick (Before Move)

### DIFF
--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -113,7 +113,9 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     bool m_eqEffectsOnly;
     bool m_eqAutoReset;
     bool m_gainAutoReset;
+#ifdef __STEM__
     bool m_stemAutoReset;
+#endif
     bool m_eqBypass;
 
     bool m_initializing;


### PR DESCRIPTION
**Issue**: #14374

This pull request updates the widget layer for knobs by modifying the **WKnobComposed::mousePressEvent** method in **wknobcomposed.cpp.** The change adds functionality to display a tooltip showing the knob’s current value in a normalized format when the user clicks the knob.

The normalized value is then formatted such that:
- If the value is exactly -1, 0, or 1 (within a tolerance of 1e-6), it is displayed without decimal places.
- Otherwise, it is displayed with two decimal places.

```
void WKnobComposed::mousePressEvent(QMouseEvent* e) {
    double rawValue = getControlParameterDisplay();
    double normalizedValue = (rawValue - 0.5) * 2.0;

    QString formattedValue;
    const double tolerance = 1e-6;
    if (std::fabs(normalizedValue + 1.0) < tolerance ||
        std::fabs(normalizedValue) < tolerance ||
        std::fabs(normalizedValue - 1.0) < tolerance) {
        formattedValue = QString::number(normalizedValue, 'f', 0);
    } else {
        formattedValue = QString::number(normalizedValue, 'f', 2);
    }

    QToolTip::showText(e->globalPos(), formattedValue);

    m_handler.mousePressEvent(this, e);
}
```

- The modification is made in the widget layer because it directly affects the visual representation of the knob. By updating **mousePressEvent**, we ensure that when a user clicks an effect knob, they immediately see a tooltip with its current normalized value. 
- The normalization **(rawValue - 0.5) * 2.0** converts the default range [0, 1] into [-1, 1] (with 0.5 becoming 0), which clearly represents the full range of control. Additionally, the formatting logic removes unnecessary decimal places for clean endpoint values (-1, 0, 1) while still providing precision for intermediate values.

**Additional Notes**
This change is currently applied to all knobs that inherit from **WKnobComposed** in Mixxx. As a result, every knob; regardless of whether it controls a primary effect or not—will display its normalized value on mouse press. On one hand, this behavior can be beneficial as it provides immediate feedback on the current knob value before any further manipulation.

However, if the intention is to restrict this tooltip display only to effect knobs (for instance, those controlling primary effects like Filter, Phaser, etc.) and not on mixer knobs or sub-effect knobs, further refinement would be needed. This could be achieved by either implementing additional logic (e.g., a conditional flag, read from the skin configuration) or by creating a dedicated subclass for the effect knobs.

I would like to seek input from the community on the best approach to limit this behavior solely to effect knobs without affecting the other controls. Any suggestions or feedback would be greatly appreciated.