### PR TITLE
[GSoC Genre] Branch Test 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1229,6 +1229,7 @@ add_library(
   src/library/dao/playlistdao.cpp
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
+  src/library/dao/genredao.cpp
   src/library/dao/trackschema.cpp
   src/library/tabledelegates/defaultdelegate.cpp
   src/library/dlgcoverartfullsize.cpp

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -585,49 +585,42 @@ reapplying those migrations.
     </sql>
   </revision>
   <revision version="40" min_compatible="3">
-    <description>
-      Multi-Genre Support:
-      - Adds 'genres' table for centralized, hiererarchical genre management.
-      - Adds 'track_genres' junction table for many-to-many track-genre links.
-      - Migrates existing single genre-from 'library.genre' to the new tables.
-    </description>
-    <sql>
-      CREATE TABLE IF NOT EXISTS genres (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name TEXT NOT NULL COLLATE NOCASE,
-        parent_id INTEGER DEFAULT NULL,
-        is_active INTEGER DEFAULT 1,
-        display_order INTEGER DEFAULT 0,
-        original_name TEXT DEFAULT NULL,
-        notes TEXT DEFAULT NULL,
-        FOREIGN KEY (parent_id) REFERENCES genres(id) ON DELETE SET NULL ON UPDATE CASCADE
-      );
+  <description>
+    Multi-Genre Support (Flat Model):
+    - Adds a 'genres' table for a centralized, flat list of genre names.
+    - Adds a 'genre_tracks' junction table for many-to-many track-genre associations.
+    - Migrates existing single genres from 'library.genre' to the new tables.
+  </description>
+  <sql>
+    CREATE TABLE IF NOT EXISTS genres (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL COLLATE NOCASE
+    );
 
-      CREATE TABLE IF NOT EXISTS genre_tracks (
-        track_id INTEGER NOT NULL,
-        genre_id INTEGER NOT NULL,
-        PRIMARY KEY (track_id, genre_id),
-        FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
-        FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
-      );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_genres_name_unique ON genres(name);
 
-      <!-- Indexes on track_id and genre_id -->
-      CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
-      CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
+    CREATE TABLE IF NOT EXISTS genre_tracks (
+      track_id INTEGER NOT NULL,
+      genre_id INTEGER NOT NULL,
+      PRIMARY KEY (track_id, genre_id),
+      FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
+      FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
+    );
 
-      <!-- Migrate existing single genre from library.genre to genres table -->
-      INSERT INTO genres (name, original_name, parent_id, is_active, display_order)
-      SELECT DISTINCT TRIM(library.genre), TRIM(library.genre), NULL, 1, 0
-      FROM library
-      WHERE library.genre IS NOT NULL AND TRIM(library.genre) != '';
+    CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
+    CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
 
-      <!-- Links library tracks to their corresponding genre IDs in track_genres -->
-      INSERT INTO genre_tracks (track_id, genre_id)
-      SELECT T.id, G.id
-      FROM library T
-      JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
-      WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
-    </sql>
-  </revision>
+    INSERT INTO genres (name)
+    SELECT DISTINCT TRIM(genre)
+    FROM library
+    WHERE genre IS NOT NULL AND TRIM(genre) != '';
+
+    INSERT INTO genre_tracks (track_id, genre_id)
+    SELECT T.id, G.id
+    FROM library T
+    JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
+    WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
+  </sql>
+</revision>
 
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -584,4 +584,50 @@ reapplying those migrations.
       UPDATE library SET filetype='aiff' WHERE filetype='aif';
     </sql>
   </revision>
+  <revision version="40" min_compatible="3">
+    <description>
+      Multi-Genre Support:
+      - Adds 'genres' table for centralized, hiererarchical genre management.
+      - Adds 'track_genres' junction table for many-to-many track-genre links.
+      - Migrates existing single genre-from 'library.genre' to the new tables.
+    </description>
+    <sql>
+      CREATE TABLE IF NOT EXISTS genres (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL COLLATE NOCASE,
+        parent_id INTEGER DEFAULT NULL,
+        is_active INTEGER DEFAULT 1,
+        display_order INTEGER DEFAULT 0,
+        original_name TEXT DEFAULT NULL,
+        notes TEXT DEFAULT NULL,
+        FOREIGN KEY (parent_id) REFERENCES genres(id) ON DELETE SET NULL ON UPDATE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS genre_tracks (
+        track_id INTEGER NOT NULL,
+        genre_id INTEGER NOT NULL,
+        PRIMARY KEY (track_id, genre_id),
+        FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
+        FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
+      );
+
+      <!-- Indexes on track_id and genre_id -->
+      CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
+      CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
+
+      <!-- Migrate existing single genre from library.genre to genres table -->
+      INSERT INTO genres (name, original_name, parent_id, is_active, display_order)
+      SELECT DISTINCT TRIM(library.genre), TRIM(library.genre), NULL, 1, 0
+      FROM library
+      WHERE library.genre IS NOT NULL AND TRIM(library.genre) != '';
+
+      <!-- Links library tracks to their corresponding genre IDs in track_genres -->
+      INSERT INTO genre_tracks (track_id, genre_id)
+      SELECT T.id, G.id
+      FROM library T
+      JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
+      WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
+    </sql>
+  </revision>
+
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -12,7 +12,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 39;
+const int MixxxDb::kRequiredSchemaVersion = 40;
 
 namespace {
 

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -1,0 +1,260 @@
+#include "library/dao/genredao.h"
+
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QVariant>
+
+#include "moc_genredao.cpp"
+#include "util/assert.h"
+#include "util/logger.h"
+
+namespace {
+const mixxx::Logger kLogger("GenreDao");
+} // anonymous namespace
+
+GenreDao::GenreDao(const QSqlDatabase& database)
+        : m_database(database) {
+    VERIFY_OR_DEBUG_ASSERT(m_database.isOpen()) {
+        kLogger.warning() << "GenreDao: Database is not open";
+    }
+}
+
+void GenreDao::initialize(const QSqlDatabase& database) {
+    VERIFY_OR_DEBUG_ASSERT(database.isOpen()) {
+        kLogger.warning() << "GenreDao: Cannot initialize with closed database";
+        return;
+    }
+    m_database = database;
+}
+
+QStringList GenreDao::getAllGenres() const {
+    QStringList genres;
+    QSqlQuery query(m_database);
+
+    if (!query.exec("SELECT name FROM genres ORDER BY name")) {
+        kLogger.warning() << "Failed to get all genres:" << query.lastError();
+        return genres;
+    }
+
+    while (query.next()) {
+        genres << query.value(0).toString();
+    }
+
+    return genres;
+}
+
+int GenreDao::getGenreIdByName(const QString& genreName) const {
+    QSqlQuery query(m_database);
+    query.prepare("SELECT id FROM genres WHERE name = ?");
+    query.bindValue(0, genreName);
+
+    if (!query.exec()) {
+        kLogger.warning() << "Failed to get genre ID for" << genreName << ":" << query.lastError();
+        return -1;
+    }
+
+    if (query.next()) {
+        return query.value(0).toInt();
+    }
+
+    return -1;
+}
+
+bool GenreDao::createGenre(const QString& genreName) {
+    QSqlQuery query(m_database);
+    query.prepare("INSERT INTO genres (name) VALUES (?)");
+    query.bindValue(0, genreName);
+
+    if (!query.exec()) {
+        kLogger.warning() << "Failed to create genre" << genreName << ":" << query.lastError();
+        return false;
+    }
+
+    int genreId = query.lastInsertId().toInt();
+    emit genreAdded(genreId);
+    return true;
+}
+
+int GenreDao::getOrCreateGenreId(const QString& genreName) {
+    VERIFY_OR_DEBUG_ASSERT(!genreName.isEmpty()) {
+        kLogger.warning() << "Cannot create genre with empty name";
+        return -1;
+    }
+
+    QString trimmedName = genreName.trimmed();
+    int existingId = getGenreIdByName(trimmedName);
+
+    if (existingId != -1) {
+        return existingId;
+    }
+
+    if (createGenre(trimmedName)) {
+        return getGenreIdByName(trimmedName);
+    }
+
+    return -1;
+}
+
+QStringList GenreDao::getTrackGenres(TrackId trackId) const {
+    QStringList genres;
+    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+        return genres;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "SELECT g.name FROM genres g "
+            "JOIN genre_tracks gt ON g.id = gt.genre_id "
+            "WHERE gt.track_id = ? "
+            "ORDER BY g.name");
+    query.bindValue(0, trackId.toVariant());
+
+    if (!query.exec()) {
+        kLogger.warning() << "Failed to get genres for track" << trackId << ":"
+                          << query.lastError();
+        return genres;
+    }
+
+    while (query.next()) {
+        genres << query.value(0).toString();
+    }
+
+    return genres;
+}
+
+bool GenreDao::setTrackGenres(TrackId trackId, const QStringList& genres) {
+    VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+        return false;
+    }
+
+    // Start transaction
+    if (!m_database.transaction()) {
+        kLogger.warning() << "Failed to start transaction for setting track genres";
+        return false;
+    }
+
+    // Remove existing genre associations
+    QSqlQuery deleteQuery(m_database);
+    deleteQuery.prepare("DELETE FROM genre_tracks WHERE track_id = ?");
+    deleteQuery.bindValue(0, trackId.toVariant());
+
+    if (!deleteQuery.exec()) {
+        kLogger.warning()
+                << "Failed to delete existing genre associations for track"
+                << trackId << ":" << deleteQuery.lastError();
+        m_database.rollback();
+        return false;
+    }
+
+    // Add new genre associations
+    for (const QString& genre : genres) {
+        QString trimmedGenre = genre.trimmed();
+        if (trimmedGenre.isEmpty()) {
+            continue;
+        }
+
+        int genreId = getOrCreateGenreId(trimmedGenre);
+        if (genreId == -1) {
+            kLogger.warning() << "Failed to get/create genre" << trimmedGenre;
+            m_database.rollback();
+            return false;
+        }
+
+        QSqlQuery insertQuery(m_database);
+        insertQuery.prepare("INSERT INTO genre_tracks (track_id, genre_id) VALUES (?, ?)");
+        insertQuery.bindValue(0, trackId.toVariant());
+        insertQuery.bindValue(1, genreId);
+
+        if (!insertQuery.exec()) {
+            kLogger.warning() << "Failed to insert genre association for track" << trackId
+                              << "genre" << trimmedGenre << ":" << insertQuery.lastError();
+            m_database.rollback();
+            return false;
+        }
+    }
+
+    // Commit transaction
+    if (!m_database.commit()) {
+        kLogger.warning() << "Failed to commit genre associations for track" << trackId;
+        return false;
+    }
+
+    emit trackGenresChanged(trackId);
+    return true;
+}
+
+bool GenreDao::addGenreToTrack(TrackId trackId, const QString& genre) {
+    QStringList currentGenres = getTrackGenres(trackId);
+    QString trimmedGenre = genre.trimmed();
+
+    if (!trimmedGenre.isEmpty() && !currentGenres.contains(trimmedGenre)) {
+        currentGenres << trimmedGenre;
+        return setTrackGenres(trackId, currentGenres);
+    }
+
+    return true; // Genre already exists or is empty
+}
+
+bool GenreDao::removeGenreFromTrack(TrackId trackId, const QString& genre) {
+    QStringList currentGenres = getTrackGenres(trackId);
+    QString trimmedGenre = genre.trimmed();
+
+    if (currentGenres.removeOne(trimmedGenre)) {
+        return setTrackGenres(trackId, currentGenres);
+    }
+
+    return true; // Genre wasn't associated with track
+}
+
+bool GenreDao::deleteGenre(int genreId) {
+    VERIFY_OR_DEBUG_ASSERT(genreId > 0) {
+        return false;
+    }
+
+    // Start transaction
+    if (!m_database.transaction()) {
+        kLogger.warning() << "Failed to start transaction for deleting genre";
+        return false;
+    }
+
+    // Delete genre associations first (due to foreign key constraint)
+    QSqlQuery deleteAssocQuery(m_database);
+    deleteAssocQuery.prepare("DELETE FROM genre_tracks WHERE genre_id = ?");
+    deleteAssocQuery.bindValue(0, genreId);
+
+    if (!deleteAssocQuery.exec()) {
+        kLogger.warning() << "Failed to delete genre associations for genre"
+                          << genreId << ":" << deleteAssocQuery.lastError();
+        m_database.rollback();
+        return false;
+    }
+
+    // Delete genre
+    QSqlQuery deleteGenreQuery(m_database);
+    deleteGenreQuery.prepare("DELETE FROM genres WHERE id = ?");
+    deleteGenreQuery.bindValue(0, genreId);
+
+    if (!deleteGenreQuery.exec()) {
+        kLogger.warning() << "Failed to delete genre" << genreId << ":"
+                          << deleteGenreQuery.lastError();
+        m_database.rollback();
+        return false;
+    }
+
+    // Commit transaction
+    if (!m_database.commit()) {
+        kLogger.warning() << "Failed to commit genre deletion for genre" << genreId;
+        return false;
+    }
+
+    emit genreDeleted(genreId);
+    return true;
+}
+
+void GenreDao::cleanupUnusedGenres() {
+    QSqlQuery query(m_database);
+    if (!query.exec("DELETE FROM genres WHERE id NOT IN (SELECT DISTINCT "
+                    "genre_id FROM genre_tracks)")) {
+        kLogger.warning() << "Failed to cleanup unused genres:" << query.lastError();
+    }
+}

--- a/src/library/dao/genredao.h
+++ b/src/library/dao/genredao.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QObject>
+#include <QSet>
+#include <QSqlDatabase>
+#include <QStringList>
+
+#include "track/trackid.h"
+
+class GenreDao : public QObject {
+    Q_OBJECT
+
+  public:
+    explicit GenreDao(const QSqlDatabase& database = QSqlDatabase());
+    ~GenreDao() override = default;
+    void initialize(const QSqlDatabase& database);
+
+    // Genre management
+    QStringList getAllGenres() const;
+    int getOrCreateGenreId(const QString& genreName);
+    bool deleteGenre(int genreId);
+
+    // Track-genre relationships
+    QStringList getTrackGenres(TrackId trackId) const;
+    bool setTrackGenres(TrackId trackId, const QStringList& genres);
+    bool addGenreToTrack(TrackId trackId, const QString& genre);
+    bool removeGenreFromTrack(TrackId trackId, const QString& genre);
+
+    // Utility methods
+    void cleanupUnusedGenres();
+
+  signals:
+    void genreAdded(int genreId);
+    void genreDeleted(int genreId);
+    void trackGenresChanged(TrackId trackId);
+
+  private:
+    QSqlDatabase m_database;
+
+    // Helper methods
+    int getGenreIdByName(const QString& genreName) const;
+    bool createGenre(const QString& genreName);
+
+    Q_DISABLE_COPY(GenreDao)
+};

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -14,6 +14,7 @@
 #include "library/coverartutils.h"
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackschema.h"
@@ -89,14 +90,16 @@ QSet<QString> collectTrackLocations(FwdSqlQuery& query) {
 } // anonymous namespace
 
 TrackDAO::TrackDAO(CueDAO& cueDao,
-                   PlaylistDAO& playlistDao,
-                   AnalysisDao& analysisDao,
-                   LibraryHashDAO& libraryHashDao,
-                   UserSettingsPointer pConfig)
+        PlaylistDAO& playlistDao,
+        AnalysisDao& analysisDao,
+        LibraryHashDAO& libraryHashDao,
+        GenreDao& genreDao,
+        UserSettingsPointer pConfig)
         : m_cueDao(cueDao),
           m_playlistDao(playlistDao),
           m_analysisDao(analysisDao),
           m_libraryHashDao(libraryHashDao),
+          m_genreDao(genreDao),
           m_pConfig(pConfig),
           m_trackLocationIdColumn(UndefinedRecordIndex),
           m_queryLibraryIdColumn(UndefinedRecordIndex),
@@ -368,6 +371,12 @@ bool TrackDAO::saveTrack(Track* pTrack) const {
         return false;
     }
 
+    // Save genres using GenreDao
+    if (!m_genreDao.setTrackGenres(trackId, pTrack->getMetadata().getGenres())) {
+        kLogger.warning() << "Failed to save genres for track" << trackId;
+        return false;
+    }
+
     // BaseTrackCache must be informed separately, because the
     // track has already been disconnected and TrackDAO does
     // not receive any signals that are usually forwarded to
@@ -596,7 +605,7 @@ void bindTrackLibraryValues(
     pTrackLibraryQuery->bindValue(":album", albumInfo.getTitle());
     pTrackLibraryQuery->bindValue(":album_artist", albumInfo.getArtist());
     pTrackLibraryQuery->bindValue(":year", trackInfo.getYear());
-    pTrackLibraryQuery->bindValue(":genre", trackInfo.getGenre());
+    // pTrackLibraryQuery->bindValue(":genre", trackInfo.getGenre());
     pTrackLibraryQuery->bindValue(":composer", trackInfo.getComposer());
     pTrackLibraryQuery->bindValue(":grouping", trackInfo.getGrouping());
     pTrackLibraryQuery->bindValue(":tracknumber", trackInfo.getTrackNumber());
@@ -1175,7 +1184,7 @@ void setTrackYear(const QSqlRecord& record, const int column, Track* pTrack) {
 }
 
 void setTrackGenre(const QSqlRecord& record, const int column, Track* pTrack) {
-    TrackDAO::setTrackGenreInternal(pTrack, record.value(column).toString());
+    pTrack->setGenre(record.value(column).toString());
 }
 
 void setTrackComposer(const QSqlRecord& record, const int column, Track* pTrack) {
@@ -1568,6 +1577,9 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
 
     // Populate track cues from the cues table.
     pTrack->setCuePoints(m_cueDao.getCuesForTrack(trackId));
+    pTrack->refMetadata().setGenres(
+            QStringList(m_genreDao.getTrackGenres(trackId).begin(),
+                    m_genreDao.getTrackGenres(trackId).end()));
     pTrack->markClean();
 
     // Synchronize the track's metadata with the corresponding source
@@ -2514,12 +2526,6 @@ bool TrackDAO::updatePlayCounterFromPlayedHistory(
     // nor receive or emit any signals.
     emit mixxx::thisAsNonConst(this)->tracksChanged(trackIds);
     return true;
-}
-
-//static
-void TrackDAO::setTrackGenreInternal(Track* pTrack, const QString& genre) {
-    DEBUG_ASSERT(pTrack);
-    pTrack->setGenreFromTrackDAO(genre);
 }
 
 //static

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "library/dao/dao.h"
+#include "library/dao/genredao.h"
 #include "library/relocatedtrack.h"
 #include "preferences/usersettings.h"
 #include "track/globaltrackcache.h"
@@ -17,6 +18,7 @@ class PlaylistDAO;
 class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
+class GenreDao;
 
 namespace mixxx {
 class FileInfo;
@@ -42,6 +44,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             PlaylistDAO& playlistDao,
             AnalysisDao& analysisDao,
             LibraryHashDAO& libraryHashDao,
+            GenreDao& genreDao,
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
 
@@ -87,7 +90,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     /// This method is invoked by a free function that needs to access
     /// a private Track member that only TrackDAO is allowed to access
     /// as a friend.
-    static void setTrackGenreInternal(Track* pTrack, const QString& genre);
+    // static void setTrackGenreInternal(Track* pTrack, const QString& genre);
     /// Don't use even if public!!! Ugly workaround for C++ visibility restrictions.
     /// This method is invoked by a free function that needs to access
     /// a private TrackRecord member that only TrackDAO is allowed to
@@ -203,6 +206,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     PlaylistDAO& m_playlistDao;
     AnalysisDao& m_analysisDao;
     LibraryHashDAO& m_libraryHashDao;
+    GenreDao& m_genreDao;
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -213,6 +213,13 @@ void DlgTrackInfo::init() {
                 m_trackRecord.refMetadata().refTrackInfo().setGenre(
                         txtGenre->text());
             });
+    connect(txtGenres,
+            &QLineEdit::editingFinished,
+            this,
+            [this]() {
+                txtGenres->setText(txtGenres->text().trimmed());
+                slotGenresChanged();
+            });
     connect(txtComposer,
             &QLineEdit::editingFinished,
             this,
@@ -409,6 +416,8 @@ void DlgTrackInfo::updateTrackMetadataFields() {
             m_trackRecord.getMetadata().getAlbumInfo().getArtist());
     txtGenre->setText(
             m_trackRecord.getMetadata().getTrackInfo().getGenre());
+    QStringList genres = m_trackRecord.getMetadata().getGenres();
+    txtGenres->setText(genres.join(" / "));
     txtComposer->setText(
             m_trackRecord.getMetadata().getTrackInfo().getComposer());
     txtGrouping->setText(
@@ -530,6 +539,27 @@ void DlgTrackInfo::focusField(const QString& property) {
         }
         it.value()->setFocus();
     }
+}
+
+void DlgTrackInfo::slotGenresChanged() {
+    QString genresText = txtGenres->text().trimmed();
+    if (genresText.isEmpty()) {
+        m_trackRecord.refMetadata().setGenres(QStringList());
+        return;
+    }
+
+    // Parse genres separated by "/"
+    QStringList genresList = genresText.split('/', Qt::SkipEmptyParts);
+    QStringList cleanGenres;
+
+    for (const QString& genre : genresList) {
+        QString trimmedGenre = genre.trimmed();
+        if (!trimmedGenre.isEmpty()) {
+            cleanGenres.append(trimmedGenre);
+        }
+    }
+
+    m_trackRecord.refMetadata().setGenres(cleanGenres);
 }
 
 void DlgTrackInfo::slotCoverFound(

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -57,6 +57,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotOk();
     void slotApply();
     void slotCancel();
+    void slotGenresChanged();
 
     void slotBpmScale(mixxx::Beats::BpmScale bpmScale);
     void slotBpmClear();

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -302,6 +302,39 @@
            </widget>
           </item>
 
+          <item row="6" column="0">
+    <widget class="QLabel" name="labelGenres">
+        <property name="text">
+            <string>Genres:</string>
+        </property>
+        <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+    </widget>
+</item>
+<item row="6" column="1">
+    <widget class="QLineEdit" name="txtGenres">
+        <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+            </sizepolicy>
+        </property>
+        <property name="minimumSize">
+            <size>
+                <width>0</width>
+                <height>0</height>
+            </size>
+        </property>
+        <property name="toolTip">
+            <string>Multiple genres separated by /</string>
+        </property>
+        <property name="placeholderText">
+            <string>Electronic / House / Deep House</string>
+        </property>
+    </widget>
+</item>
+
           <item row="5" column="2">
            <widget class="QLabel" name="lblKey">
             <property name="text">

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -100,7 +100,8 @@ LibraryScanner::LibraryScanner(
         const UserSettingsPointer& pConfig)
         : m_pDbConnectionPool(std::move(pDbConnectionPool)),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, pConfig),
+          m_genreDao(QSqlDatabase()),
+          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, m_genreDao, pConfig),
           m_stateSema(1), // only one transaction is possible at a time
           m_state(IDLE),
           m_manualScan(true) {
@@ -172,6 +173,7 @@ void LibraryScanner::run() {
         m_trackDao.initialize(dbConnection);
         m_playlistDao.initialize(dbConnection);
         m_analysisDao.initialize(dbConnection);
+        m_genreDao.initialize(dbConnection);
         m_directoryDao.initialize(dbConnection);
 
         // Start the event loop.

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -11,6 +11,7 @@
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
 #include "library/dao/directorydao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
@@ -111,6 +112,7 @@ class LibraryScanner : public QThread {
     PlaylistDAO m_playlistDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    GenreDao m_genreDao;
     TrackDAO m_trackDao;
 
     // Global scanner state for scan currently in progress.

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -16,12 +16,16 @@ mixxx::Logger kLogger("TrackCollection");
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
-        QObject* parent,
-        const UserSettingsPointer& pConfig)
+        QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao,
-                     m_analysisDao, m_libraryHashDao, pConfig) {
+          m_genreDao(m_database),
+          m_trackDao(m_cueDao,
+                  m_playlistDao,
+                  m_analysisDao,
+                  m_libraryHashDao,
+                  m_genreDao,
+                  pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
             &TrackDAO::trackDirty,
@@ -77,6 +81,7 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);
     m_libraryHashDao.initialize(database);
+    m_genreDao.initialize(database);
     m_crates.connectDatabase(database);
 }
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -9,6 +9,7 @@
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
 #include "library/dao/directorydao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
@@ -67,6 +68,10 @@ class TrackCollection : public QObject,
     AnalysisDao& getAnalysisDAO() {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_analysisDao;
+    }
+    GenreDao& getGenreDAO() {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        return m_genreDao;
     }
 
     void connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSource);
@@ -172,6 +177,7 @@ class TrackCollection : public QObject,
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
     LibraryHashDAO m_libraryHashDao;
+    GenreDao m_genreDao;
     TrackDAO m_trackDao;
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1976,6 +1976,86 @@ bool Track::updateGenre(
     return true;
 }
 
+void Track::setGenre(const QString& genre) {
+    auto locked = lockMutex(&m_qMutex);
+    QStringList genres;
+    if (!genre.trimmed().isEmpty()) {
+        genres << genre.trimmed();
+    }
+    if (compareAndSet(
+                m_record.refMetadata().ptrGenres(),
+                genres)) {
+        markDirtyAndUnlock(&locked);
+        emit genreChanged(getGenre());
+    }
+}
+
+QStringList Track::getGenres() const {
+    const auto locked = lockMutex(&m_qMutex);
+    return m_record.getMetadata().getGenres();
+}
+
+void Track::setGenres(const QStringList& genres) {
+    auto locked = lockMutex(&m_qMutex);
+    QStringList cleanGenres;
+    for (const QString& genre : genres) {
+        QString trimmed = genre.trimmed();
+        if (!trimmed.isEmpty() && !cleanGenres.contains(trimmed)) {
+            cleanGenres.append(trimmed);
+        }
+    }
+    if (compareAndSet(
+                m_record.refMetadata().ptrGenres(),
+                cleanGenres)) {
+        markDirtyAndUnlock(&locked);
+        emit genreChanged(getGenre());
+    }
+}
+
+void Track::addGenre(const QString& genre) {
+    auto locked = lockMutex(&m_qMutex);
+    QString trimmed = genre.trimmed();
+    if (trimmed.isEmpty()) {
+        return;
+    }
+
+    QStringList currentGenres = m_record.getMetadata().getGenres();
+    if (!currentGenres.contains(trimmed)) {
+        currentGenres.append(trimmed);
+        if (compareAndSet(
+                    m_record.refMetadata().ptrGenres(),
+                    currentGenres)) {
+            markDirtyAndUnlock(&locked);
+            emit genreChanged(getGenre());
+        }
+    }
+}
+
+void Track::removeGenre(const QString& genre) {
+    auto locked = lockMutex(&m_qMutex);
+    QString trimmed = genre.trimmed();
+    QStringList currentGenres = m_record.getMetadata().getGenres();
+    if (currentGenres.removeOne(trimmed)) {
+        if (compareAndSet(
+                    m_record.refMetadata().ptrGenres(),
+                    currentGenres)) {
+            markDirtyAndUnlock(&locked);
+            emit genreChanged(getGenre());
+        }
+    }
+}
+
+void Track::clearGenres() {
+    auto locked = lockMutex(&m_qMutex);
+    QStringList emptyGenres;
+    if (compareAndSet(
+                m_record.refMetadata().ptrGenres(),
+                emptyGenres)) {
+        markDirtyAndUnlock(&locked);
+        emit genreChanged(getGenre());
+    }
+}
+
 #if defined(__EXTRA_METADATA__)
 QString Track::getMood() const {
     const auto locked = lockMutex(&m_qMutex);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -226,6 +226,24 @@ class Track : public QObject {
             /*TODO: const mixxx::TaggingConfig& config,*/
             const QString& genre);
 
+    /// Set the genre text (single genre for backward compatibility)
+    void setGenre(const QString& genre);
+
+    /// Get all genres as a list
+    QStringList getGenres() const;
+
+    /// Set multiple genres
+    void setGenres(const QStringList& genres);
+
+    /// Add a genre to the track
+    void addGenre(const QString& genre);
+
+    /// Remove a genre from the track
+    void removeGenre(const QString& genre);
+
+    /// Clear all genres
+    void clearGenres();
+
 #if defined(__EXTRA_METADATA__)
     /// Return the mood as text
     QString getMood() const;
@@ -636,6 +654,11 @@ class Track : public QObject {
     /// TODO: Remove and populate TrackRecord from the database instead.
     void setGenreFromTrackDAO(
             const QString& genre);
+
+    /// Access to the track's metadata for multi-genre support
+    mixxx::TrackMetadata& refMetadata() {
+        return m_record.refMetadata();
+    }
 
     friend class GlobalTrackCache;
     friend class GlobalTrackCacheResolver;

--- a/src/track/trackmetadata.cpp
+++ b/src/track/trackmetadata.cpp
@@ -152,6 +152,7 @@ QString TrackMetadata::reformatYear(const QString& year) {
 void TrackMetadata::normalizeBeforeExport() {
     m_albumInfo.normalizeBeforeExport();
     m_trackInfo.normalizeBeforeExport();
+    m_genres.removeDuplicates();
 }
 
 bool TrackMetadata::anyFileTagsModified(
@@ -162,13 +163,15 @@ bool TrackMetadata::anyFileTagsModified(
     // been updated while decoding audio data. They are read-only and
     // must not be considered when exporting metadata!
     return getAlbumInfo() != importedFromFile.getAlbumInfo() ||
-            !getTrackInfo().compareEq(importedFromFile.getTrackInfo(), cmpBpm);
+            !getTrackInfo().compareEq(importedFromFile.getTrackInfo(), cmpBpm) ||
+            getGenres() != importedFromFile.getGenres();
 }
 
 bool operator==(const TrackMetadata& lhs, const TrackMetadata& rhs) {
     return lhs.getStreamInfo() == rhs.getStreamInfo() &&
             lhs.getAlbumInfo() == rhs.getAlbumInfo() &&
-            lhs.getTrackInfo() == rhs.getTrackInfo();
+            lhs.getTrackInfo() == rhs.getTrackInfo() &&
+            lhs.getGenres() == rhs.getGenres();
 }
 
 QDebug operator<<(QDebug dbg, const TrackMetadata& arg) {
@@ -176,8 +179,38 @@ QDebug operator<<(QDebug dbg, const TrackMetadata& arg) {
     arg.dbgStreamInfo(dbg);
     arg.dbgTrackInfo(dbg);
     arg.dbgAlbumInfo(dbg);
+    arg.dbgGenres(dbg);
     dbg << '}';
     return dbg;
+}
+
+void TrackMetadata::addGenre(const QString& genre) {
+    QString trimmedGenre = genre.trimmed();
+    if (!trimmedGenre.isEmpty() && !m_genres.contains(trimmedGenre)) {
+        m_genres.append(trimmedGenre);
+    }
+}
+
+void TrackMetadata::removeGenre(const QString& genre) {
+    m_genres.removeAll(genre.trimmed());
+}
+
+void TrackMetadata::clearGenres() {
+    m_genres.clear();
+}
+
+QString TrackMetadata::getGenre() const {
+    if (m_genres.isEmpty()) {
+        return QString();
+    }
+    return m_genres.first();
+}
+
+void TrackMetadata::setGenre(const QString& genre) {
+    m_genres.clear();
+    if (!genre.trimmed().isEmpty()) {
+        m_genres.append(genre.trimmed());
+    }
 }
 
 } // namespace mixxx

--- a/src/track/trackmetadata.h
+++ b/src/track/trackmetadata.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDateTime>
+#include <QStringList>
 
 #include "audio/streaminfo.h"
 #include "track/albuminfo.h"
@@ -20,11 +21,20 @@ class TrackMetadata final {
     //   - stored in file tags
     MIXXX_DECL_PROPERTY(AlbumInfo, albumInfo, AlbumInfo)
     MIXXX_DECL_PROPERTY(TrackInfo, trackInfo, TrackInfo)
+    MIXXX_DECL_PROPERTY(QStringList, genres, Genres)
 
   public:
     TrackMetadata() = default;
     TrackMetadata(TrackMetadata&&) = default;
     TrackMetadata(const TrackMetadata&) = default;
+    // Multi-genre support
+    void addGenre(const QString& genre);
+    void removeGenre(const QString& genre);
+    void clearGenres();
+
+    // Legacy single genre support (for backward compatibility)
+    QString getGenre() const;
+    void setGenre(const QString& genre);
     /*non-virtual*/ ~TrackMetadata() = default;
 
     TrackMetadata& operator=(TrackMetadata&&) = default;


### PR DESCRIPTION
This is a branch to test changes and upgrades during GSoC development project.

**Backend Infrastructure** 

_Database Access Layer_
**GenreDao Implementation:** Complete CRUD operations for genre management
- Transaction-safe operations with rollback support
- Case-insensitive genre matching and normalization
- Automatic cleanup of unused genres
- Get-or-create pattern for efficient genre management

_Data Model Extensions_
**TrackMetadata Enhancement:** Extended to support QStringList for multiple genres
- Maintains backward compatibility with single genre access
- Added genre collection methods (add, remove, clear)
- Updated comparison operators to include genre comparison

_Track Management Integration_
**Track Class Updates:** Added comprehensive genre management methods
- Thread-safe operations with proper mutex locking
- Dirty state tracking and signal emission for UI updates
- Support for both single and multiple genre workflows

_System Architecture Updates_
**TrackDAO Integration:** Seamless integration of genre operations into existing workflow
- Atomic save operations ensuring data consistency
- Proper foreign key constraint handling

**TrackCollection Integration:** Added GenreDao as managed component
**LibraryScanner Compatibility:** Updated scanner infrastructure for multi-genre support

**User Interface** 
_Track Info Dialog Enhancement_

**New Genres Field:** Added dedicated field for multiple genre input
- Positioned below existing Genre field for backward compatibility
- Placeholder text: "Electronic / House / Deep House"
- Tooltip explaining "/" separator usage
- Automatic input validation and trimming

_Data Binding_
**UI-Backend Integration:** Connected genres field to TrackMetadata
- Real-time parsing of "/" separated genre input
- Automatic synchronization with track metadata
- Proper focus handling and input validation

**Technical Implementation**
_Database Schema_
- Utilizes existing normalized genre structure from schema version 40
- Many-to-many relationship between tracks and genres
- Foreign key constraints with CASCADE deletion

**Backward Compatibility** 
- Maintains full compatibility with existing single-genre workflows
- Existing code continues to work without modification
- Gradual migration path for users and external integrations

**Future Enhancements**
This implementation provides the foundation for:
- Library search integration for multiple genres
- Enhanced table view displaying all genres
- ID3 tag reading/writing for multiple genres
- Auto-complete suggestions for genre input
- Genre-based filtering and smart playlists

**Files Modified**

_Backend Files_
`src/library/dao/genredao.h` - Genre DAO interface
`src/library/dao/genredao.cpp` - Genre DAO implementation
`src/track/trackmetadata.h` - Multi-genre metadata support
`src/track/track.h` - Track genre management interface
`src/track/track.cpp` - Track genre management implementation
`src/library/dao/trackdao.h` - TrackDAO integration
`src/library/dao/trackdao.cpp` - TrackDAO implementation updates
`src/library/trackcollection.h` - GenreDao integration
`src/library/trackcollection.cpp` - Collection management updates
`src/library/scanner/libraryscanner.h` - Scanner integration
`src/library/scanner/libraryscanner.cpp` - Scanner implementation

Frontend Files

`src/library/dlgtrackinfo.ui` - Track Info Dialog UI layout
`src/library/dlgtrackinfo.h` - Dialog header with new slot
`src/library/dlgtrackinfo.cpp` - Dialog implementation and logic